### PR TITLE
Look for the api_key in $_COOKIE rather than $_REQUEST.

### DIFF
--- a/fever/fever_api.php
+++ b/fever/fever_api.php
@@ -138,8 +138,8 @@ class FeverAPI extends Handler {
 				file_put_contents(self::DEBUG_FILE,'auth POST: '.json_encode($output)."\n",FILE_APPEND);
 			}
 		}
-		if ((strlen($apikey)==0)&&isset($_REQUEST['fever_auth'])) { // override for Mr.Reader when doing some stuff
-			$apikey = $_REQUEST['fever_auth'];
+		if ((strlen($apikey)==0)&&isset($_COOKIE['fever_auth'])) { // override for Mr.Reader when doing some stuff
+			$apikey = $_COOKIE['fever_auth'];
 		}
 		if (strlen($apikey)>0)
 		{


### PR DESCRIPTION
For Mr. Reader, we set a cookie on the login message and then look for
it on subsequent requests. We need to check $_COOKIE rather than
$_REQUEST though as the values in $_REQUEST are set within php.ini and
cookies are not often set there since the PHP org changed the default
setting of "request_order" to be "GP".
