### PR TITLE
Update fever_api.php to support Article class

### DIFF
--- a/fever/fever_api.php
+++ b/fever/fever_api.php
@@ -558,7 +558,7 @@ class FeverAPI extends Handler {
 		{
 			$line_content = $this->my_sanitize($line["content"], $line["link"]);
 			if (ADD_ATTACHED_FILES){
-				$enclosures = get_article_enclosures($line["id"]);
+				$enclosures = Article::get_article_enclosures($line["id"]);
 				if (count($enclosures) > 0) {
 					$line_content .= '<ul type="lower-greek">';
 					foreach ($enclosures as $enclosure) {


### PR DESCRIPTION
The latest commit to tt-rss now has classes for various objects, including an Article class, which causes errors in the plugin. This update make the plugin functional again.