### PR TITLE
Fixes #31: Feeds no longer sync to Reeder for iOS with TT-RSS v17.4.

### DIFF
--- a/fever/fever_api.php
+++ b/fever/fever_api.php
@@ -558,7 +558,7 @@ class FeverAPI extends Handler {
 		{
 			$line_content = $this->my_sanitize($line["content"], $line["link"]);
 			if (ADD_ATTACHED_FILES){
-				$enclosures = get_article_enclosures($line["id"]);
+				$enclosures = Article::get_article_enclosures($line["id"]);
 				if (count($enclosures) > 0) {
 					$line_content .= '<ul type="lower-greek">';
 					foreach ($enclosures as $enclosure) {
@@ -713,7 +713,7 @@ class FeverAPI extends Handler {
 					WHERE ref_id IN ($article_ids)");
 
 				while ($line = $this->dbh->fetch_assoc($result)) {
-					ccache_update($line["feed_id"], $_SESSION["uid"]);
+					CCache::update($line["feed_id"], $_SESSION["uid"]);
 				}
 			}
 		}
@@ -782,7 +782,7 @@ class FeverAPI extends Handler {
 								AND owner_uid = '" . db_escape_string($_SESSION["uid"]) . "' AND unread = true AND feed_id = " . intval($id) . " AND date_entered < '" . date("Y-m-d H:i:s", $before) . "' ) as tmp)");
 
 			}
-			ccache_update($id,$_SESSION["uid"], $cat);
+			CCache::update($id,$_SESSION["uid"], $cat);
 		}
 	}
 


### PR DESCRIPTION
Rename get_article_enclosures() to Article::get_article_enclosures()
and ccache_update() to CCache::update().