### PR TITLE
Fixed problems with newer PHP and ttrss versions

### DIFF
--- a/fever/fever_api.php
+++ b/fever/fever_api.php
@@ -19,6 +19,13 @@ class FeverAPI extends Handler {
 
 	private $xml;
 
+	private $dbh;
+
+	function __construct()
+	{
+		$this->dbh = Db::get();
+	}
+
 	// always include api_version, status as 'auth'
 	// output json/xml
 	function wrap($status, $reply)

--- a/fever/fever_api.php
+++ b/fever/fever_api.php
@@ -557,8 +557,8 @@ class FeverAPI extends Handler {
 		while ($line = $this->dbh->fetch_assoc($result))
 		{
 			$line_content = $this->my_sanitize($line["content"], $line["link"]);
-			if (ADD_ATTACHED_FILES){
-				$enclosures = get_article_enclosures($line["id"]);
+			if (self::ADD_ATTACHED_FILES){
+				$enclosures = Article::get_article_enclosures($line["id"]);
 				if (count($enclosures) > 0) {
 					$line_content .= '<ul type="lower-greek">';
 					foreach ($enclosures as $enclosure) {


### PR DESCRIPTION
### Problem 1
Two fixes, a missing `self::`s (will not work in current PHP versions) and a missing `Article::` (the latter is also addressed in two other (rather stale) pull requests, [A](https://github.com/dasmurphy/tinytinyrss-fever-plugin/pull/25), [B](https://github.com/dasmurphy/tinytinyrss-fever-plugin/pull/32).)

### Problem 2
Since [some refactoring in ttrss](https://git.tt-rss.org/fox/tt-rss/commit/df5d2a06657be3abb671c44295848afefc7f8fd4) the mother `Handler` class lost its `dbh` (database handle) property, which is used excessively by this plugin. Re-added the property locally in the `FeverAPI` class and added initialization in the constructor.

Note: this is a minimal-invasive workaround for refactoring the whole plugin to use a proper database connection. Since that, ttrss core will throw deprecation notices (`PHP Notice:  Legacy connect requested to mysql in /var/www/html/classes/db.php on line 22`), like hell.