### PR TITLE
Return total_items as int instead of string

### DIFF
--- a/fever/fever_api.php
+++ b/fever/fever_api.php
@@ -607,7 +607,7 @@ class FeverAPI extends Handler {
 			$total_items = $this->dbh->fetch_result($result, 0, "total_items");
 		}
 
-		return $total_items;
+		return (int) $total_items;
 	}
 
 	function getFeedsGroup()


### PR DESCRIPTION
This PR fixed the format of total_items. 

Before: 

```
{
  "api_version": 3,
  "auth": 1,
  "last_refreshed_on_time": "1594991257",
  "total_items": "17126",
  "items": [
    {
      "id": 1239,
```

After 

```
{
  "api_version": 3,
  "auth": 1,
  "last_refreshed_on_time": "1594991257",
  "total_items": 17126,
  "items": [
    {
      "id": 1239,
```